### PR TITLE
Convert default value of floating-point columns to floats

### DIFF
--- a/lib/convergence/column.rb
+++ b/lib/convergence/column.rb
@@ -27,6 +27,11 @@ class Convergence::Column
     timestamp
     year
   )
+  FLOATING_POINT_COLUMN_TYPE = %i(
+    float
+    double
+    decimal
+  )
 
   def initialize(type, column_name, options = {})
     @type = type

--- a/lib/convergence/table.rb
+++ b/lib/convergence/table.rb
@@ -3,6 +3,9 @@ class Convergence::Table
 
   Convergence::Column::COLUMN_TYPE.each do |column_type|
     define_method "#{column_type}" do |column_name, options = {}|
+      if Convergence::Column::FLOATING_POINT_COLUMN_TYPE.include?(column_type) && !options[:default].nil?
+        options[:default] = options[:default].to_f
+      end
       @columns[column_name.to_s] = Convergence::Column.new(column_type, column_name.to_s, options)
     end
   end

--- a/spec/convergence/table_spec.rb
+++ b/spec/convergence/table_spec.rb
@@ -20,6 +20,11 @@ describe Convergence::Table do
       table.int(dummy_column, limit: 100)
       expect(table.columns[dummy_column].options[:limit]).to eq(100)
     end
+
+    it 'should convert the default value to float for floating-point columns' do
+      table.decimal(dummy_column, default: 1)
+      expect(table.columns[dummy_column].options[:default]).to eq(1.0)
+    end
   end
 
   describe '#index' do


### PR DESCRIPTION
When creating floating-point columns with integer defaults, convergence will try to modify the column every time because the default value in the schema (integer 0) differs from the one in the database (float 0.0). MySQL always converts the default value to a floating-point value.