### PR TITLE
Feature/add auto increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,13 @@ create_table "authors", comment: 'Author', engine: 'MyISAM', collate: "utf8_gene
 end
 ```
 
+### auto increment
+
+```
+create_table "orders", auto_increment: 1000 do |t|
+  t.int :id, primary_key: true, extra: :auto_increment
+end
+```
 
 ## Test
 

--- a/lib/convergence/diff.rb
+++ b/lib/convergence/diff.rb
@@ -154,6 +154,9 @@ class Convergence::Diff
       .reject do |k, v|
         !from.table_options[k].nil? && from.table_options[k].to_s.downcase == v.to_s.downcase
       end
+    if remove_auto_increment_option?(from.table_options[:auto_increment], to.table_options[:auto_increment])
+      change_options.delete(:auto_increment)
+    end
     Hash[change_options]
   end
 
@@ -163,5 +166,10 @@ class Convergence::Diff
 
   def case_sensitive_column?(column)
     CASE_SENSITIVE_COLUMNS.include?(column)
+  end
+
+  def remove_auto_increment_option?(from_value, to_value)
+    return false if from_value.nil? || to_value.nil?
+    from_value >= to_value
   end
 end

--- a/lib/convergence/dumper/mysql_schema_dumper.rb
+++ b/lib/convergence/dumper/mysql_schema_dumper.rb
@@ -111,6 +111,7 @@ class Convergence::Dumper::MysqlSchemaDumper
     option.merge!(default_charset: table_option['CHARACTER_SET_NAME'])
     option.merge!(collate: table_option['TABLE_COLLATION'])
     option.merge!(comment: table_option['TABLE_COMMENT'])
+    option.merge!(auto_increment: table_option['AUTO_INCREMENT']) if table_option['AUTO_INCREMENT']
     table.table_options = option
   end
 

--- a/lib/convergence/sql_generator/mysql_generator.rb
+++ b/lib/convergence/sql_generator/mysql_generator.rb
@@ -4,7 +4,8 @@ class SQLGenerator::MysqlGenerator < SQLGenerator
     row_format: 'ROW_FORMAT',
     default_charset: 'DEFAULT CHARACTER SET',
     collate: 'COLLATE',
-    comment: 'COMMENT'
+    comment: 'COMMENT',
+    auto_increment: 'AUTO_INCREMENT'
   }
   QUOTE_OPTION = [:comment]
 


### PR DESCRIPTION
```
create_table :orders, auto_increment: 1000 do |t|
  t.int :id, primary_key: true, extra: :auto_increment
end
```

↓

```
SET FOREIGN_KEY_CHECKS=0;
  --> 0.00047123502008616924s
CREATE TABLE `orders` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB ROW_FORMAT=Compact DEFAULT CHARACTER SET=utf8 AUTO_INCREMENT=1000 COLLATE=utf8_general_ci;
  --> 0.014681472966913134s
SET FOREIGN_KEY_CHECKS=1;
  --> 0.00012843398144468665s
```