### PR TITLE
Replace a position of `require 'mysql2'`

### DIFF
--- a/lib/convergence/database_connector/mysql_connector.rb
+++ b/lib/convergence/database_connector/mysql_connector.rb
@@ -1,3 +1,4 @@
+require 'mysql2'
 class Convergence::DatabaseConnector::MysqlConnector
   attr_reader :config
 

--- a/lib/convergence/dumper/mysql_schema_dumper.rb
+++ b/lib/convergence/dumper/mysql_schema_dumper.rb
@@ -1,4 +1,3 @@
-require 'mysql2'
 class Convergence::Dumper::MysqlSchemaDumper
   def initialize(connector)
     @connector = connector


### PR DESCRIPTION
It had been placed in `lib/convergence/dumper/mysql_schema_dumper.rb``.
However, mysql2 is used by `lib/convergence/database_connector/mysql_connector.rb`.