### PR TITLE
Improve default value of column limit

### DIFF
--- a/lib/convergence/default_parameter/mysql_default_parameter.rb
+++ b/lib/convergence/default_parameter/mysql_default_parameter.rb
@@ -52,19 +52,19 @@ class Convergence::DefaultParameter::MysqlDefaultParameter
   TEXT_TYPE = [:varchar, :char, :tiny_text, :text, :mediumtext, :longtext]
   DEFAULT_COLUMN_TYPE_PARAMETERS = {
     tinyint: {
-      limit: 3
+      limit: 4
     },
     smallint: {
-      limit: 5
+      limit: 6
     },
     mediumint: {
-      limit: 8
+      limit: 9
     },
     int: {
       limit: 11
     },
     bigint: {
-      limit: 19
+      limit: 20
     },
     varchar: {
       limit: 255


### PR DESCRIPTION
### Change overview
I changed default values of column limit to same value as default value of MySQL.

### Example table
#### DDL
``` sql
create table sample (
  t tinyint,
  s smallint,
  m mediumint,
  i int,
  b bigint
);
```

#### MySQL default value
```
+-------+--------------+------+-----+---------+-------+
| Field | Type         | Null | Key | Default | Extra |
+-------+--------------+------+-----+---------+-------+
| t     | tinyint(4)   | YES  |     | NULL    |       |
| s     | smallint(6)  | YES  |     | NULL    |       |
| m     | mediumint(9) | YES  |     | NULL    |       |
| i     | int(11)      | YES  |     | NULL    |       |
| b     | bigint(20)   | YES  |     | NULL    |       |
+-------+--------------+------+-----+---------+-------+
```

### Convergence behavior
#### Example schema
``` ruby
create_table "sample" do |t|
  t.tinyint :t
  t.smallint :s
  t.mediumint :m
  t.int :i
  t.bigint :b
end
```

#### Expected
```
$ ./bin/convergence -c database.yml -i sample.schema --apply
SET FOREIGN_KEY_CHECKS=0;
  --> 0.0006840950009063818s
CREATE TABLE `sample` (
  `t` tinyint(4) NOT NULL,
  `s` smallint(6) NOT NULL,
  `m` mediumint(9) NOT NULL,
  `i` int(11) NOT NULL,
  `b` bigint(20) NOT NULL
) ENGINE=InnoDB ROW_FORMAT=Compact DEFAULT CHARACTER SET=utf8 COLLATE=utf8_general_ci;
  --> 0.015671902998292353s
SET FOREIGN_KEY_CHECKS=1;
  --> 0.00025019500026246533s
```

#### Actual (v0.2.1)
```
$ ./bin/convergence -c database.yml -i sample.schema --apply
SET FOREIGN_KEY_CHECKS=0;
  --> 0.0010523210003157146s
CREATE TABLE `sample` (
  `t` tinyint(3) NOT NULL,
  `s` smallint(5) NOT NULL,
  `m` mediumint(8) NOT NULL,
  `i` int(11) NOT NULL,
  `b` bigint(19) NOT NULL
) ENGINE=InnoDB ROW_FORMAT=Compact DEFAULT CHARACTER SET=utf8 COLLATE=utf8_general_ci;
  --> 0.013574398995842785s
SET FOREIGN_KEY_CHECKS=1;
  --> 0.00020541200501611456s
```