### PR TITLE
Improve alter table queries

### DIFF
--- a/lib/convergence/sql_generator/mysql_generator.rb
+++ b/lib/convergence/sql_generator/mysql_generator.rb
@@ -37,8 +37,8 @@ class SQLGenerator::MysqlGenerator < SQLGenerator
       unless table_delta[:remove_column].empty?
         results << alter_remove_columns_sql(table_name, table_delta[:remove_column].values)
       end
-      table_delta[:add_column].each do |_column_name, column|
-        results << alter_add_column_sql(table_name, column)
+      unless table_delta[:add_column].empty?
+        results << alter_add_columns_sql(table_name, table_delta[:add_column].values)
       end
       table_delta[:change_column].each do |column_name, column|
         results << alter_change_column_sql(table_name, column_name, column, to_table)
@@ -56,8 +56,11 @@ class SQLGenerator::MysqlGenerator < SQLGenerator
     results
   end
 
-  def alter_add_column_sql(table_name, column)
-    %(ALTER TABLE `#{table_name}` ADD COLUMN #{create_column_sql(column, output_primary_key: true)};)
+  def alter_add_columns_sql(table_name, columns)
+    sql = %(ALTER TABLE `#{table_name}`\n)
+    sql += columns.map { |column| %(  ADD COLUMN #{create_column_sql(column, output_primary_key: true)}) }.join(",\n")
+    sql += ';'
+    sql
   end
 
   def alter_remove_columns_sql(table_name, columns)

--- a/lib/convergence/sql_generator/mysql_generator.rb
+++ b/lib/convergence/sql_generator/mysql_generator.rb
@@ -34,8 +34,8 @@ class SQLGenerator::MysqlGenerator < SQLGenerator
       table_delta[:remove_index].each do |index_name, _index|
         results << alter_remove_index_sql(table_name, index_name)
       end
-      table_delta[:remove_column].each do |_column_name, column|
-        results << alter_remove_column_sql(table_name, column)
+      unless table_delta[:remove_column].empty?
+        results << alter_remove_columns_sql(table_name, table_delta[:remove_column].values)
       end
       table_delta[:add_column].each do |_column_name, column|
         results << alter_add_column_sql(table_name, column)
@@ -60,8 +60,11 @@ class SQLGenerator::MysqlGenerator < SQLGenerator
     %(ALTER TABLE `#{table_name}` ADD COLUMN #{create_column_sql(column, output_primary_key: true)};)
   end
 
-  def alter_remove_column_sql(table_name, column)
-    %(ALTER TABLE `#{table_name}` DROP COLUMN `#{column.column_name}`;)
+  def alter_remove_columns_sql(table_name, columns)
+    sql = %(ALTER TABLE `#{table_name}`\n)
+    sql += columns.map { |column| %(  DROP COLUMN `#{column.column_name}`) }.join(",\n")
+    sql += ';'
+    sql
   end
 
   def alter_change_column_sql(table_name, column_name, change_column_option, to_table)

--- a/spec/integrations/command_dryrun.rb
+++ b/spec/integrations/command_dryrun.rb
@@ -58,7 +58,7 @@ describe 'Command::Dryrun#execute' do
 
     it 'should be output alter drop column query' do
       result = execute(exec_dsl)
-      expect(result).to be_include('# ALTER TABLE `authors` DROP COLUMN `name`;')
+      expect(result).to be_include("# ALTER TABLE `authors`\n#   DROP COLUMN `name`;")
     end
   end
 

--- a/spec/integrations/command_dryrun.rb
+++ b/spec/integrations/command_dryrun.rb
@@ -49,7 +49,7 @@ describe 'Command::Dryrun#execute' do
 
     it 'should be output alter add column query' do
       result = execute(exec_dsl)
-      expect(result).to be_include('# ALTER TABLE `authors` ADD COLUMN `add_column` varchar(110) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL AFTER `name`;')
+      expect(result).to be_include("# ALTER TABLE `authors`\n#   ADD COLUMN `add_column` varchar(110) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL AFTER `name`;")
     end
   end
 


### PR DESCRIPTION
### Overview
I changed alter table query to be combined same kind queries.

### Example output
#### Add columns
``` sql
ALTER TABLE `hoge`
  ADD COLUMN `column1` int(11) DEFAULT NULL AFTER `id`,
  ADD COLUMN `column2` int(11) DEFAULT NULL AFTER `column1`;
  --> 0.04083801299566403s
```

#### Remove columns
``` sql
ALTER TABLE `fuga`
  DROP COLUMN `column1`,
  DROP COLUMN `column2`;
  --> 0.045134596002753824s
```

#### Add foreign keys
``` sql
ALTER TABLE `hoge`
  ADD CONSTRAINT `hoge_column1_fk` FOREIGN KEY (column1) REFERENCES `fuga`(id),
  ADD CONSTRAINT `hoge_column2_fk` FOREIGN KEY (column2) REFERENCES `fuga`(id);
  --> 0.04170248300215462s
```

#### Remove foreign keys
``` sql
ALTER TABLE `hoge`
  DROP FOREIGN KEY `hoge_column1_fk`,
  DROP FOREIGN KEY `hoge_column2_fk`;
  --> 0.010096778998558875s
DROP INDEX `hoge_column1_fk` ON `hoge`;
  --> 0.008224488999985624s
DROP INDEX `hoge_column2_fk` ON `hoge`;
  --> 0.013555179997638334s
```


### Limitation
* Change column alter table queries are not combined.
* Other kind alter table queries are not combined.
  * e.g. add column and remove column are not combined.
    ``` sql
    ALTER TABLE `hoge`
       DROP COLUMN `column1`;
    ALTER TABLE `hoge`
       ADD COLUMN `column2` int(11) DEFAULT NULL AFTER `id`;
    ```