### PR TITLE
Specify required ruby version

### DIFF
--- a/convergence.gemspec
+++ b/convergence.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diffy'
   spec.add_dependency 'slop', '~> 3.6'
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
Convergence v0.2.4 or later does not work on Ruby 2.2 or earlier.