### PR TITLE
Fix diff option

### DIFF
--- a/lib/convergence/command/diff.rb
+++ b/lib/convergence/command/diff.rb
@@ -17,10 +17,12 @@ class Convergence::Command::Diff < Convergence::Command
   private
 
   def from_tables
-    Convergence::DSL.parse(File.open(@opts[:diff][0]).read)
+    current_dir_path = Pathname.new(@opts[:diff][0]).realpath.dirname
+    Convergence::DSL.parse(File.open(@opts[:diff][0]).read, current_dir_path)
   end
 
   def to_tables
-    Convergence::DSL.parse(File.open(@opts[:diff][1]).read)
+    current_dir_path = Pathname.new(@opts[:diff][1]).realpath.dirname
+    Convergence::DSL.parse(File.open(@opts[:diff][1]).read, current_dir_path)
   end
 end


### PR DESCRIPTION
diff option does not work since v0.0.5
```
$ bundle exec convergence --diff schema_1.rb --diff schema_2.rb
bundler: failed to load command: convergence (/home/foo/.rbenv/versions/2.3.1/bin/convergence)
ArgumentError: wrong number of arguments (given 1, expected 2)
  /home/foo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/convergence-0.2.4/lib/convergence/dsl.rb:20:in `parse'
  /home/foo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/convergence-0.2.4/lib/convergence/command/diff.rb:20:in `from_tables'
  /home/foo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/convergence-0.2.4/lib/convergence/command/diff.rb:10:in `execute'
  /home/foo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/convergence-0.2.4/lib/convergence/command.rb:23:in `execute'
  /home/foo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/convergence-0.2.4/bin/convergence:23:in `<top (required)>'
  /home/foo/.rbenv/versions/2.3.1/bin/convergence:23:in `load'
  /home/foo/.rbenv/versions/2.3.1/bin/convergence:23:in `<top (required)>'
```