### PR TITLE
Support MySQL identifiers that require quotes in Ruby symbol syntax on export dsl

### DIFF
--- a/lib/convergence/dumper.rb
+++ b/lib/convergence/dumper.rb
@@ -6,7 +6,7 @@ class Convergence::Dumper
   end
 
   def dump_table_dsl(table)
-    table_argument = [":#{table.table_name}"]
+    table_argument = [table.table_name.to_sym.inspect]
     table_argument << table.table_options.map { |k, v| key_value_text(k, v) }
     dsl = "create_table #{table_argument.flatten.join(', ')} do |t|\n"
     dsl += "  #{table.columns.map { |_, column| dump_column(column) }.join("\n  ")}"
@@ -27,7 +27,7 @@ class Convergence::Dumper
   private
 
   def dump_column(column)
-    argument = [%(:#{column.column_name})]
+    argument = [column.column_name.to_sym.inspect]
     case [column.type, column.options[:limit]]
     when [:tinyint, '1']
       column_type = "boolean"
@@ -63,9 +63,9 @@ class Convergence::Dumper
   def single_or_multiple_symbol(values)
     values_array = [values].flatten
     if values_array.size == 1
-      ":#{values_array.first}"
+      values_array.first.to_sym.inspect
     else
-      %(#{values.map(&:to_sym)})
+      values.map(&:to_sym).inspect
     end
   end
 
@@ -79,6 +79,6 @@ class Convergence::Dumper
   end
 
   def key_value_symbol(k, v)
-    "#{k}: :#{v}"
+    "#{k}: #{v.to_sym.inspect}"
   end
 end

--- a/spec/convergence/dumper_spec.rb
+++ b/spec/convergence/dumper_spec.rb
@@ -36,5 +36,35 @@ end
       dsl = Convergence::Dumper.new.dump_table_dsl(table1)
       expect(dsl).to eq(table1_dsl)
     end
+
+    context "when MySQL identifiers that require quotes in Ruby symbol syntax" do
+      let(:table1) do
+        Convergence::Table.new('dummy-table', engine: 'MyISAM').tap do |t|
+          t.int :id, limit: 11
+          t.varchar :"column-1", limit: 100, null: true, comment: 'column 1'
+
+          t.index :"column-1", name: 'idx_column-1'
+          t.foreign_key :"column-1", reference: 'dummy-ref', reference_column: :"dummy-column"
+        end
+      end
+
+      let(:table1_dsl) do
+        dsl = <<-DSL
+create_table :"dummy-table", engine: "MyISAM" do |t|
+  t.int :id, limit: 11
+  t.varchar :"column-1", limit: 100, null: true, comment: "column 1"
+
+  t.index :"column-1", name: "idx_column-1"
+  t.foreign_key :"column-1", reference: :"dummy-ref", reference_column: :"dummy-column", name: "dummy-table_column-1_fk"
+end
+      DSL
+        dsl.strip
+      end
+
+      it 'should be able to dump dsl' do
+        dsl = Convergence::Dumper.new.dump_table_dsl(table1)
+        expect(dsl).to eq(table1_dsl)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Overview

I modified the export dsl command to work fine even if MySQL identifiers that require quotes in Ruby symbol syntax(e.g. including -).

## Example output
### Before (a6f1bd2c7dd6a618d7afa59c87c88e2a074ad6f3)

following code has a syntax error.

```
$ ./bin/convergence -c database.yml -e
create_table :test-table-1, collate: "utf8_general_ci", comment: "", auto_increment: 1 do |t|
  t.int :id, primary_key: true, extra: "auto_increment"
  t.varchar :column-1, limit: 100
  t.datetime :created_at
  t.datetime :updated_at

  t.index :column-1, name: "index_test-table-1_on_column-1", unique: true
end

create_table :test-table-2, collate: "utf8_general_ci", comment: "", auto_increment: 1 do |t|
  t.int :id, primary_key: true, extra: "auto_increment"
  t.varchar :test-table-1-column-1, limit: 100
  t.varchar :column-2, null: true, limit: 100
  t.datetime :created_at
  t.datetime :updated_at

  t.index :column-2, name: "index_test-table-2_on_column-2"
  t.foreign_key :test-table-1-column-1, reference: :test-table-1, reference_column: :column-1, name: "test-table-2_test-table-1-column-1_fk"
end
```

### After (1a0c685ab8322a5891a352a2b5eac6daea1784bd)

following code works fine.

```
$ ./bin/convergence -c database.yml -e
create_table :"test-table-1", collate: "utf8_general_ci", comment: "", auto_increment: 1 do |t|
  t.int :id, primary_key: true, extra: "auto_increment"
  t.varchar :"column-1", limit: 100
  t.datetime :created_at
  t.datetime :updated_at

  t.index :"column-1", name: "index_test-table-1_on_column-1", unique: true
end

create_table :"test-table-2", collate: "utf8_general_ci", comment: "", auto_increment: 1 do |t|
  t.int :id, primary_key: true, extra: "auto_increment"
  t.varchar :"test-table-1-column-1", limit: 100
  t.varchar :"column-2", null: true, limit: 100
  t.datetime :created_at
  t.datetime :updated_at

  t.index :"column-2", name: "index_test-table-2_on_column-2"
  t.foreign_key :"test-table-1-column-1", reference: :"test-table-1", reference_column: :"column-1", name: "test-table-2_test-table-1-column-1_fk"
end
```