### PR TITLE
Output help message when executed without option

### DIFF
--- a/lib/convergence/command.rb
+++ b/lib/convergence/command.rb
@@ -19,7 +19,9 @@ class Convergence::Command
       elsif @opts[:apply]
         Convergence::Command::Apply
       end
-    unless execute_klass.nil?
+    if execute_klass.nil?
+      puts @opts
+    else
       execute_klass.new(@opts, config: @config).execute
     end
   end


### PR DESCRIPTION
## Overview
I changed it to display help message when executed without option.

## Output

### Before
```
$ ./bin/convergence

```
### After
```
$ ./bin/convergence
Usage: convergence [options]
    -v, --version
    -c, --config       Database Yaml Setting
    -d, --diff         DSL1,DSL2
    -e, --export       export db schema to dsl
    -i, --input        Input DSL
        --dryrun
        --apply        execute sql to your database
    -h, --help         Display this help message.

```