### PR TITLE
Fix issues of `Convergence::Config`

### DIFF
--- a/lib/convergence/config.rb
+++ b/lib/convergence/config.rb
@@ -15,7 +15,7 @@ class Convergence::Config
   end
 
   def self.load(yaml_path)
-    setting = YAML.load(ERB.new(File.read(yaml_path)).result)
+    setting = YAML.safe_load(ERB.new(File.read(yaml_path)).result, [], [], true)
     new(setting)
   end
 end

--- a/lib/convergence/config.rb
+++ b/lib/convergence/config.rb
@@ -2,11 +2,15 @@ require 'erb'
 require 'yaml'
 
 class Convergence::Config
-  attr_accessor :adapter, :database, :host, :port, :username, :password
+  ATTRIBUTES = %i[adapter database host port username password].freeze
+
+  attr_accessor(*ATTRIBUTES)
 
   def initialize(attributes)
     attributes.each do |k, v|
-      instance_variable_set("@#{k}", v) unless v.nil?
+      next if v.nil?
+      next if !ATTRIBUTES.include?(k.to_sym) && !ATTRIBUTES.include?(k.to_s)
+      instance_variable_set("@#{k}", v)
     end
   end
 


### PR DESCRIPTION
I fixed following issues of `Convergence::Config`.

* Unnecessary instance variables assignments
  before: 
  ``` 
  [1] pry(main)> require "convergence"
    => true
  [2] pry(main)> Convergence::Config.new(foo: "bar")
  => #<Convergence::Config:0x00007fd2a2ece9e8 @foo="bar">
  ```
  after:
  ```
  [1] pry(main)> require "convergence"
  => true
  [2] pry(main)> Convergence::Config.new(foo: "bar")
  => #<Convergence::Config:0x00007f81f1b494a0>
  ```
* RuboCop offence of `Security/YAMLLoad`
  * https://github.com/rubocop-hq/rubocop/blob/v0.51.0/config/enabled.yml#L1853-L1858