### PR TITLE
Fix rspec config for focus filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ DEPENDENCIES
   guard-rspec
   pry
   rake (~> 10.0)
-  rspec
+  rspec (>= 3.5)
   rubocop
 
 BUNDLED WITH

--- a/convergence.gemspec
+++ b/convergence.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '>= 3.5'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'guard'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,5 @@ def rollback
 end
 
 RSpec.configure do |config|
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
RSpec was changed to use `config.filter_run_when_matching` instead of `config.filter_run` and `config.run_all_when_everything_filtered` in v3.5.0.
ref. https://github.com/rspec/rspec-core/blob/v3.5.0/Changelog.md#350beta3--2016-04-02