### PR TITLE
Change to not output extra blank line if dry-run message is empty

### DIFF
--- a/lib/convergence/command/dryrun.rb
+++ b/lib/convergence/command/dryrun.rb
@@ -41,7 +41,7 @@ class Convergence::Command::Dryrun < Convergence::Command
       .split("\n")
       .map { |v| '# ' + v }
       .join("\n")
-    logger.output(msg)
+    logger.output(msg) unless msg.empty?
     msg
   end
 end


### PR DESCRIPTION
Before:
```
$ ./bin/convergence apply example.schema -c database.yml --dry-run

$
```

After:
```
$ ./bin/convergence apply example.schema -c database.yml --dry-run
$
```
