### PR TITLE
Add rollback dryrun command

### DIFF
--- a/lib/convergence/cli.rb
+++ b/lib/convergence/cli.rb
@@ -6,17 +6,21 @@ require 'convergence/config'
 
 class Convergence::CLI < Thor
   default_command :__fallback # TODO: `__fallback` will be removed in a future version(maybe v1.1.0)
- 
+
   map %w[--version -v] => :version
 
   desc 'apply FILE', 'execute sql to your database'
   method_option :config, aliases: '-c', type: :string, required: true, desc: 'Database Yaml Setting'
   method_option :dry_run, type: :boolean
+  method_option :rollback_dry_run, type: :boolean
   def apply(file)
     opts = { input: file }
     if options[:dry_run]
       require 'convergence/command/dryrun'
       Convergence::Command::Dryrun.new(opts, config: config).execute
+    elsif options[:rollback_dry_run]
+      require 'convergence/command/rollback_dryrun'
+      Convergence::Command::RollbackDryrun.new(opts, config: config).execute
     else
       require 'convergence/command/apply'
       Convergence::Command::Apply.new(opts, config: config).execute

--- a/lib/convergence/command/rollback_dryrun.rb
+++ b/lib/convergence/command/rollback_dryrun.rb
@@ -1,0 +1,32 @@
+require 'pathname'
+require 'convergence/command'
+require 'convergence/command/apply'
+require 'convergence/dsl'
+require 'convergence/default_parameter'
+
+class Convergence::Command::RollbackDryrun < Convergence::Command
+  def validate!
+    fail ArgumentError.new('config required') if @config.nil?
+    fail ArgumentError.new('input required') unless @opts[:input]
+  end
+
+  def execute
+    validate!
+    current_dir_path = Pathname.new(@opts[:input]).realpath.dirname
+    input_tables = Convergence::DSL.parse(File.open(@opts[:input]).read, current_dir_path)
+    current_tables = dumper.dump
+
+    output_sql(current_tables, input_tables)
+  end
+
+  def output_sql(input_tables, current_tables)
+    msg = Convergence::Command::Apply
+      .new(@opts, config: @config)
+      .generate_sql(input_tables, current_tables)
+      .split("\n")
+      .map { |v| '# ' + v }
+      .join("\n")
+    logger.output(msg)
+    msg
+  end
+end


### PR DESCRIPTION
I want to generate migration queries like up and down of Rails DB migration command.

```
class AddUserIdToUserTrackings < ActiveRecord::Migration[5.2]
  def up
    execute <<-EOS
      ALTER TABLE `user_trackings` ADD COLUMN `user_id` int(11) NOT NULL AFTER `event_name`
    EOS
  end

  def down
    execute <<-EOS
      ALTER TABLE `user_trackings` DROP COLUMN `user_id`;
    EOS
  end
end
```

To create it, I added a command called rollback-dryrun.

```
bundle exec convergence apply --config=database.yml schema.rb --rollback-dry-run
```

----

example.

I defined the following schema.rb, and add user_id(int) column to user_tracking table. 

```
create_table :user_trackings, row_format: "Dynamic", default_charset: "utf8mb4", collate: "utf8mb4_general_ci" do |t|
  t.int :id, primary_key: true, extra: "auto_increment"
  t.varchar :event_name, null: true
+  t.int :user_id
  t.datetime :created_at, null: true
end
```

The result of dryrun is as follows.

```
$ bundle exec convergence apply --config=database.yml schema.rb --dry-run

# ALTER TABLE `user_trackings`
#   ADD COLUMN `user_id` int(11) NOT NULL AFTER `event_name`;
```

And the result of rollback-dryrun is as following.

```
$ bundle exec convergence apply --config=database.yml schema.rb --rollback-dry-run

# ALTER TABLE `user_trackings`
#   DROP COLUMN `user_id`;
```