### PR TITLE
Support ssl connections

### DIFF
--- a/convergence.gemspec
+++ b/convergence.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diffy'
   spec.add_dependency 'thor', '~> 0.20'
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/convergence/config.rb
+++ b/lib/convergence/config.rb
@@ -4,13 +4,43 @@ require 'yaml'
 class Convergence::Config
   ATTRIBUTES = %i[adapter database host port username password].freeze
 
-  attr_accessor(*ATTRIBUTES)
+  attr_accessor(*ATTRIBUTES, :mysql)
+
+  class MySQL
+    ATTRIBUTES = %i[ssl_mode sslkey sslcert sslca sslcapath sslcipher sslverify].freeze
+
+    attr_accessor(*ATTRIBUTES)
+
+    def initialize(attributes)
+      attributes.each do |k, v|
+        next if v.nil?
+        next if !ATTRIBUTES.include?(k.to_sym) && !ATTRIBUTES.include?(k.to_s)
+        instance_variable_set("@#{k}", v)
+      end
+    end
+
+    def ssl_options
+      {
+        ssl_mode: ssl_mode,
+        sslkey: sslkey,
+        sslcert: sslcert,
+        sslca: sslca,
+        sslcapath: sslcapath,
+        sslcipher: sslcipher,
+        sslverify: sslverify
+      }.compact
+    end
+  end
 
   def initialize(attributes)
     attributes.each do |k, v|
       next if v.nil?
       next if !ATTRIBUTES.include?(k.to_sym) && !ATTRIBUTES.include?(k.to_s)
       instance_variable_set("@#{k}", v)
+    end
+    case adapter
+    when 'mysql', 'mysql2'
+      @mysql = MySQL.new(attributes)
     end
   end
 

--- a/lib/convergence/database_connector/mysql_connector.rb
+++ b/lib/convergence/database_connector/mysql_connector.rb
@@ -10,21 +10,25 @@ class Convergence::DatabaseConnector::MysqlConnector
 
   def client(database_name = @config.database)
     @mysql ||= Mysql2::Client.new(
-      host: @config.host,
-      port: @config.port,
-      username: @config.username,
-      password: @config.password,
-      database: database_name
+      {
+        host: @config.host,
+        port: @config.port,
+        username: @config.username,
+        password: @config.password,
+        database: database_name
+      }.merge!(@config.mysql.ssl_options)
     )
   end
 
   def schema_client
     @schema_mysql ||= Mysql2::Client.new(
-      host: @config.host,
-      port: @config.port,
-      username: @config.username,
-      password: @config.password,
-      database: 'information_schema'
+      {
+        host: @config.host,
+        port: @config.port,
+        username: @config.username,
+        password: @config.password,
+        database: 'information_schema'
+      }.merge!(@config.mysql.ssl_options)
     )
   end
 end


### PR DESCRIPTION
I would like to use ssl connections to connect mysql server.
I added this support using [ssl options of mysql2 client](https://github.com/brianmario/mysql2/tree/4e221cfdec4edfc08dfd1bf0ee405d695af813ee#ssl-options).

close #68

----

example configuration file:
``` yaml
adapter: mysql
database: convergence_test
host: 127.0.0.1
username: root
password:
sslca: /path/to/ca-cert.pem
sslverify: true
```