### PR TITLE
Fix warning on Ruby 2.6 and later

### DIFF
--- a/lib/convergence/dumper.rb
+++ b/lib/convergence/dumper.rb
@@ -70,7 +70,7 @@ class Convergence::Dumper
   end
 
   def key_value_text(k, v)
-    value = if v.to_s == 'true' || v.to_s == 'false' || v =~ /^\d+$/
+    value = if v.to_s == 'true' || v.to_s == 'false' || v.to_s =~ /^\d+$/
               v
             else
               %(#{v.inspect})


### PR DESCRIPTION
I fixed following warning on Ruby 2.6 and later.
```
/home/yujideveloper/oss/convergence/lib/convergence/dumper.rb:73: warning: deprecated Object#=~ is called on Integer; it always returns nil
```