### PR TITLE
Migrate CI from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Start MySQL
+      run: sudo systemctl start mysql.service
+    - name: Prepare database
+      run: bundle exec rake db:convergence:prepare
+    - name: Run tests
+      run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-  - 2.4.1
-services:
-  - mysql
-script:
-  - bundle install
-  - bundle exec rake db:convergence:prepare
-  - bundle exec rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -13,18 +13,18 @@ namespace :db do
     desc 'Build the databases for tests'
     task :build_databases do
       query = "create database #{mysql_settings[:database]};"
-      system("mysql -u #{mysql_settings[:username]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} -e '#{query}'")
+      system("mysql -u #{mysql_settings[:username]} -p#{mysql_settings[:password]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} -e '#{query}'")
     end
 
     task :drop_databases do
       query = "drop database #{mysql_settings[:database]};"
-      system("mysql -u #{mysql_settings[:username]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} -e '#{query}'")
+      system("mysql -u #{mysql_settings[:username]} -p#{mysql_settings[:password]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} -e '#{query}'")
     end
 
     desc 'Create tables on tests databases'
     task :create_tables do
       query_path = "#{File.dirname(__FILE__)}/spec/fixtures/test_db.sql"
-      system("mysql -u #{mysql_settings[:username]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} #{mysql_settings[:database]} < #{query_path}")
+      system("mysql -u #{mysql_settings[:username]} -p#{mysql_settings[:password]} -h #{mysql_settings[:host]} --port #{mysql_settings[:port]} #{mysql_settings[:database]} < #{query_path}")
     end
 
     desc 'Prepare the test databases'

--- a/spec/config/spec_database.yml
+++ b/spec/config/spec_database.yml
@@ -1,6 +1,7 @@
 mysql:
   adapter: mysql2
   database: convergence_test_db
-  host: localhost
-  port: 3389
+  host: 127.0.0.1
+  port: 3306
   username: root
+  password: root


### PR DESCRIPTION
travis-ci.org was shutdown on 2021/05/31.
I migrated CI from Travis CI to GitHub Actions.