### PR TITLE
Run CI test with specific version of MySQL service

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: Test with MySQL ${{ matrix.mysql }}, Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.mysql == '8.0' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Install dependencies
       run: bundle install
     - name: Start MySQL

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,11 +4,25 @@ on: [push, pull_request]
 
 jobs:
   test:
+    name: Test with MySQL ${{ matrix.mysql }}, Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        mysql: ['5.7', '8.0']
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql }}
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
@@ -18,8 +32,6 @@ jobs:
         bundler-cache: true
     - name: Install dependencies
       run: bundle install
-    - name: Start MySQL
-      run: sudo systemctl start mysql.service
     - name: Prepare database
       run: bundle exec rake db:convergence:prepare
     - name: Run tests


### PR DESCRIPTION
The test was failing because the version of MySQL in the ubuntu-latest image using for testing was implicitly changed from 5.7 to 8.0.  
Although it does not solve the fundamental problem, I have made a change to fix the version of MySQL used in CI, so please check it.

FYI. https://tmsick.hatenablog.jp/entry/2021/05/23/040357#%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AE-character-set