### PR TITLE
Don't try to quote functions or expressions passed to :default option if they are passed as procs.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: Test with MySQL ${{ matrix.mysql }}, Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.mysql == '8.0' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Install dependencies
       run: bundle install
     - name: Start MySQL

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,11 +4,25 @@ on: [push, pull_request]
 
 jobs:
   test:
+    name: Test with MySQL ${{ matrix.mysql }}, Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        mysql: ['5.7', '8.0']
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql }}
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
@@ -18,8 +32,6 @@ jobs:
         bundler-cache: true
     - name: Install dependencies
       run: bundle install
-    - name: Start MySQL
-      run: sudo systemctl start mysql.service
     - name: Prepare database
       run: bundle exec rake db:convergence:prepare
     - name: Run tests

--- a/lib/convergence/diff.rb
+++ b/lib/convergence/diff.rb
@@ -76,14 +76,16 @@ class Convergence::Diff
       .map do |column_name, from_column|
         to_column = to.columns[column_name]
         if to_column
-          to_column_option_with_type = (from_column.options.map { |k, _v| { k => nil } }.reduce { |a, e| a.merge(e) } || {})
+          to_column_option_with_type = (from_column.options.map { |k, _v| [k, nil] }.to_h)
             .merge(to_column.options)
             .merge(type: to_column.type)
+            .tap { |opt| opt[:default] = opt[:default].call if opt[:default].is_a?(Proc) }
             .map { |k, v| [k, case_sensitive_column?(k) ? v&.to_s : v&.to_s&.downcase] }
             .to_a
           from_column_option_with_type = from_column
             .options
             .merge(type: from_column.type)
+            .tap { |opt| opt[:default] = opt[:default].call if opt[:default].is_a?(Proc) }
             .map { |k, v| [k, case_sensitive_column?(k) ? v&.to_s : v&.to_s&.downcase] }
             .to_a
           { column_name => Hash[(to_column_option_with_type - from_column_option_with_type)] }

--- a/lib/convergence/dumper.rb
+++ b/lib/convergence/dumper.rb
@@ -72,6 +72,8 @@ class Convergence::Dumper
   def key_value_text(k, v)
     value = if v.to_s == 'true' || v.to_s == 'false' || v.to_s =~ /^\d+$/
               v
+            elsif v.is_a?(Proc)
+              %(-> { #{v.call.inspect} })
             else
               %(#{v.inspect})
             end

--- a/lib/convergence/sql_generator/mysql_generator.rb
+++ b/lib/convergence/sql_generator/mysql_generator.rb
@@ -188,7 +188,7 @@ DROP TABLE `#{table_name}`;
       sql += ' PRIMARY KEY'
     end
     if column.options[:default]
-      sql += " DEFAULT '#{column.options[:default]}'"
+      sql += " DEFAULT #{quote_default_expression(column.options[:default])}"
     end
     if column.options[:comment]
       sql += " COMMENT '#{column.options[:comment]}'"
@@ -243,5 +243,13 @@ DROP TABLE `#{table_name}`;
         "#{key}=#{v}"
       end
     end.join(' ')
+  end
+
+  def quote_default_expression(value)
+    if value.is_a?(Proc)
+      value.call
+    else
+      %('#{value}')
+    end
   end
 end

--- a/spec/convergence/dumper/mysql_schema_dumper_spec.rb
+++ b/spec/convergence/dumper/mysql_schema_dumper_spec.rb
@@ -37,14 +37,17 @@ describe Convergence::Dumper::MysqlSchemaDumper do
         expect(papers.columns['title1']).not_to be_nil
         expect(papers.columns['title2']).not_to be_nil
         expect(papers.columns['description']).not_to be_nil
+        expect(papers.columns['edition_number']).not_to be_nil
+        expect(papers.columns['published_at']).not_to be_nil
       end
 
       it 'should be dump columns in the correct order' do
         papers = subject['papers']
-        expect(papers.columns.keys).to eq(%w(id slug title1 title2 description))
+        expect(papers.columns.keys)
+          .to eq(%w(id slug title1 title2 description edition_number published_at))
       end
 
-      describe 'table options' do
+      describe 'table column options' do
         it 'should be dump primary key' do
           expect(subject['papers'].columns['id'].options[:primary_key]).to be_truthy
         end
@@ -68,6 +71,13 @@ describe Convergence::Dumper::MysqlSchemaDumper do
 
         it 'should be dump unsigned definition' do
           expect(subject['authors'].columns['age'].options[:unsigned]).to be_truthy
+        end
+
+        it 'should be dump default' do
+          expect(subject['papers'].columns['edition_number'].options[:default]).to eq "0"
+          expect(subject['papers'].columns['published_at'].options[:default])
+            .to be_a(Proc)
+            .and have_attributes(call: "CURRENT_TIMESTAMP")
         end
       end
     end

--- a/spec/convergence/dumper_spec.rb
+++ b/spec/convergence/dumper_spec.rb
@@ -13,15 +13,15 @@ describe Convergence::Dumper do
     end
   end
   let(:table1_dsl) do
-    dsl = <<-DSL
-create_table :dummy_table, engine: "MyISAM" do |t|
-  t.int :id, limit: 11
-  t.varchar :name, limit: 100, null: true, comment: "name"
+    dsl = <<~DSL
+      create_table :dummy_table, engine: "MyISAM" do |t|
+        t.int :id, limit: 11
+        t.varchar :name, limit: 100, null: true, comment: "name"
 
-  t.index :name, name: "idx_name"
-  t.foreign_key :id, reference: :dummy_ref, reference_column: :id, name: "dummy_table_id_fk"
-end
-  DSL
+        t.index :name, name: "idx_name"
+        t.foreign_key :id, reference: :dummy_ref, reference_column: :id, name: "dummy_table_id_fk"
+      end
+    DSL
     dsl.strip
   end
 
@@ -51,15 +51,39 @@ end
       end
 
       let(:table1_dsl) do
-        dsl = <<-DSL
-create_table :"dummy-table", engine: "MyISAM" do |t|
-  t.int :id, limit: 11
-  t.varchar :"column-1", limit: 100, null: true, comment: "column 1"
+        dsl = <<~DSL
+          create_table :"dummy-table", engine: "MyISAM" do |t|
+            t.int :id, limit: 11
+            t.varchar :"column-1", limit: 100, null: true, comment: "column 1"
 
-  t.index :"column-1", name: "idx_column-1"
-  t.foreign_key :"column-1", reference: :"dummy-ref", reference_column: :"dummy-column", name: "dummy-table_column-1_fk"
-end
-      DSL
+            t.index :"column-1", name: "idx_column-1"
+            t.foreign_key :"column-1", reference: :"dummy-ref", reference_column: :"dummy-column", name: "dummy-table_column-1_fk"
+          end
+        DSL
+        dsl.strip
+      end
+
+      it 'should be able to dump dsl' do
+        dsl = Convergence::Dumper.new.dump_table_dsl(table1)
+        expect(dsl).to eq(table1_dsl)
+      end
+    end
+
+    context "when the table column has default option with proc" do
+      let(:table1) do
+        Convergence::Table.new('dummy_table').tap do |t|
+          t.int :edition_number, default: 0
+          t.datetime :created_at, default: -> { "CURRENT_TIMESTAMP" }
+        end
+      end
+
+      let(:table1_dsl) do
+        dsl = <<~DSL
+          create_table :dummy_table do |t|
+            t.int :edition_number, default: 0
+            t.datetime :created_at, default: -> { "CURRENT_TIMESTAMP" }
+          end
+        DSL
         dsl.strip
       end
 

--- a/spec/fixtures/change_table_comment_to_paper.schema
+++ b/spec/fixtures/change_table_comment_to_paper.schema
@@ -14,6 +14,8 @@ create_table "papers", collate: "utf8_general_ci", comment: "Paper" do |t|
   t.varchar "title1", limit: 300, comment: "Title 1"
   t.varchar "title2", limit: 300, comment: "Title 2"
   t.text "description", null: true, comment: "Description"
+  t.int "edition_number", default: 0
+  t.datetime "published_at", default: -> { "CURRENT_TIMESTAMP" }
 end
 
 create_table "paper_authors", collate: "utf8_general_ci", comment: "Paper Author Relation" do |t|

--- a/spec/fixtures/test_db.sql
+++ b/spec/fixtures/test_db.sql
@@ -8,6 +8,8 @@ CREATE TABLE `papers` (
   `title1` varchar(300) NOT NULL COMMENT 'Title 1',
   `title2` varchar(300) NOT NULL COMMENT 'Title 2',
   `description` text COMMENT 'Description',
+  `edition_number` int(11) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Edition number',
+  `published_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Published at',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_papers_on_slug` (`slug`),
   KEY `index_papers_on_title1_title2` (`title1` (100), `title2` (200))


### PR DESCRIPTION
after #86

Allow passing a proc to the `Convergence::Column` 's `:default` option, as ActiveRecord supports.
With this change, for example, the MySQL's `CURRENT_TIMESTAMP()` function can be used for the initial value of datetime type columns.

See also: https://github.com/rails/rails/pull/20005